### PR TITLE
Reduce editorcontainerbox's bottom margin

### DIFF
--- a/pad.css
+++ b/pad.css
@@ -42,6 +42,10 @@ html {
     padding: none;
 }
 
+.mobile-layout #editorcontainerbox {
+    margin-bottom: 5px;   
+}
+
 .toolbar ul.menu_right li[data-key="savedRevision"] {
     display: none;
 }


### PR DESCRIPTION
Mobile's layout (the one BigBlueButton is using) is getting some extra distance from the bottom margin.
I believe this happens because Etherpad's regular mobile view gets an extra bar at the bottom. Since we
do not use this bar we should reduce this bottom margin.

from

![big](https://user-images.githubusercontent.com/1778398/111640702-36170d00-87db-11eb-86b5-3e03aa29e2fe.png)

to

![small](https://user-images.githubusercontent.com/1778398/111640754-416a3880-87db-11eb-8c7b-0fde61ba292d.png)