### PR TITLE
feat(icon): change import/export icon

### DIFF
--- a/pad.css
+++ b/pad.css
@@ -157,3 +157,8 @@ html {
         transform: scale(1.0);
     }
 }
+
+.buttonicon-import_export::before {
+    /* file-download icon */
+    content: "\e858" !important;
+}


### PR DESCRIPTION
Overwrite the default import/export icon to a more common one

![image](https://user-images.githubusercontent.com/42683590/157708566-8797da21-3345-4dec-b663-684c11704be3.png)


cc: @pedrobmarin @alangecker 

closes: https://github.com/alangecker/bbb-etherpad-skin/issues/2