### PR TITLE
fix(etherpad): bottom text crop

### DIFF
--- a/pad.css
+++ b/pad.css
@@ -5,7 +5,9 @@ html {
     background: #fff;
 }
 
-#innerdocbody { 
+#innerdocbody {
+  padding-top: 2px;
+  padding-bottom: unset;
   font-family: Verdana, Arial, Helvetica, sans-serif;
   color: #4e5a66;
 }
@@ -107,6 +109,8 @@ html {
 }
 
 #sidediv {
+    padding-top: 2px;
+    padding-bottom: unset;
     border: none;
 }
 


### PR DESCRIPTION
Decrease the padding-top property that causes bottom text being cut off for
viewers

closes: https://github.com/alangecker/bbb-etherpad-skin/issues/4